### PR TITLE
:bug: FE_하단 navbar를 통해 메뉴 이동 시 네비게이션 백스택 추가 로직 수정

### DIFF
--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/BeepApp.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/BeepApp.kt
@@ -62,7 +62,11 @@ fun BeepApp() {
     LaunchedEffect(loginState.isUserLoggedIn) {
         if (token != null) {
             if (token.isEmpty()) {
-                navController.navigate("login_main_graph")
+                navController.navigate("login_main_graph") {
+                    popUpTo("home") {
+                        inclusive = true
+                    }
+                }
             }
         }
     }
@@ -98,7 +102,12 @@ fun BeepApp() {
                 ),
                 navController = navController,
                 onItemClick = {
-                    navController.navigate(it.route)
+                    val backStackEntry = navController.currentBackStackEntry
+                    if (backStackEntry?.destination?.route != it.route) {
+                        navController.navigate(it.route) {
+                            popUpTo("home")
+                        }
+                    }
                 },
             )
         }
@@ -164,7 +173,11 @@ fun BeepAppBar(
                         .background(color = BLUE400.copy(0.0F))
                         .clickable {
                             if(checkState == "dictionaryList") {
-                                navController.navigate("home")
+                                navController.navigate("home") {
+                                    popUpTo("home") {
+                                        inclusive = true
+                                    }
+                                }
                             } else {
                                 navController.navigate("dictionaryList")
                             }

--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
@@ -37,7 +37,11 @@ fun JoinScreen(navController: NavController) {
         Log.d("launchEffect 실행", "$loginState")
         if (token != null) {
             if (token.isNotBlank()) {
-                navController.navigate("beep_graph")
+                navController.navigate("beep_graph") {
+                    popUpTo("login_graph") {
+                        inclusive = true
+                    }
+                }
             }
         }
     }

--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/LoginScreen.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/LoginScreen.kt
@@ -49,7 +49,11 @@ fun LoginScreen(
         Log.d("launchEffect 실행", "$loginState")
         if (token != null) {
             if (token.isNotBlank()) {
-                navController.navigate("beep_graph")
+                navController.navigate("beep_graph") {
+                    popUpTo("login_graph") {
+                        inclusive = true
+                    }
+                }
             }
         }
     }

--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/MainButtonScreen.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/MainButtonScreen.kt
@@ -60,7 +60,11 @@ fun MainButtonScreen(navController: NavController) {
                 verticalArrangement = Arrangement.Bottom,
             ) {
                 Button(
-                    onClick = { navController.navigate("login_graph") },
+                    onClick = { navController.navigate("login_graph") {
+                        popUpTo("login_main_graph") {
+                            inclusive = true
+                        }
+                    } },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(40.dp)


### PR DESCRIPTION
1. 기존에는 하단 navbar를 통해 메뉴를 이동할 경우 목적지 composable이 모두 백스택에 추가돼 취소버튼을 누르면 기존에 추가됐던 모든 메뉴를 거쳐가는 현상이 있었습니다.

- 현재 위치로 이동하는 navbar 버튼을 다시 누를 경우 백스택에 추가되지 않도록 했습니다.

- 다른 위치로 이동하는 navbar 버튼을 누를 경우 home화면까지 백스택을 비운 뒤 새 목적지를 추가하고 이동하도록 했습니다.
    - 로그인 풀렸을 때 건너뛰기 : ui/navigation/RootNavGraph.kt의 isLoggedDestination을 "beep_graph"로 바꾸면 로그인을 건너뛰고 화면 테스트 할 수 있음

- 로그인 화면의 경우 로그인이 완료되면 관련 composable을 백스택에서 모두 비우도록 했습니다(서버 없어서 테스트는 못해봄)