### PR TITLE
:sparkles:  FE_회원가입 시 개인정보 처리방침 확인 기능 추가

### DIFF
--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
@@ -183,7 +183,7 @@ fun JoinScreen(navController: NavController) {
                         if (!viewModel.authState.acceptedTerms) {
                             val uri = "https://sites.google.com/view/beep661661/%ED%99%88"
                             val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
-                            startActivity(context, browserIntent, null)
+                            context.startActivity(browserIntent)
                         }
                         viewModel.onEvent(AuthFormEvent.AcceptTerms(it))
                     }

--- a/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
+++ b/Frontend/Beep/app/src/main/java/com/example/beep/ui/login/JoinScreen.kt
@@ -1,5 +1,7 @@
 package com.example.beep.ui.login
 
+import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.ui.Alignment
@@ -19,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
+import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.beep.di.MainApplication
@@ -177,6 +180,11 @@ fun JoinScreen(navController: NavController) {
                 Checkbox(
                     checked = state.acceptedTerms,
                     onCheckedChange = {
+                        if (!viewModel.authState.acceptedTerms) {
+                            val uri = "https://sites.google.com/view/beep661661/%ED%99%88"
+                            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+                            startActivity(context, browserIntent, null)
+                        }
                         viewModel.onEvent(AuthFormEvent.AcceptTerms(it))
                     }
                 )


### PR DESCRIPTION
1. Intent를 통해 개인정보 처리방침에 동의함에 체크하면 브라우저에서 개인정보 처리방침이 열리도록 구현함.